### PR TITLE
Update indicator document

### DIFF
--- a/jobs/mysql-metrics/templates/indicators.yml.erb
+++ b/jobs/mysql-metrics/templates/indicators.yml.erb
@@ -1,113 +1,129 @@
 ---
-apiVersion: v0
-product:
-  name: mysql-pxc
-  version: v2.5
+apiVersion: indicatorprotocol.io/v1
+kind: IndicatorDocument
 
 metadata:
-  deployment: <%= spec.deployment %>
-  source_id: <%= p("mysql-metrics.source_id") %>
-  origin: <%= p("mysql-metrics.origin").gsub(/[^A-Z,a-z,0-9]/,"_") %>
+  labels:
+    deployment: <%= spec.deployment %>
+    source_id: <%= p("mysql-metrics.source_id") %>
+    origin: <%= p("mysql-metrics.origin").gsub(/[^A-Z,a-z,0-9]/,"_") %>
 
-indicators:
-- name: mysql_availability
-  promql:  _$origin_available{source_id="$source_id", deployment="$deployment"}
-  thresholds:
-  - level: critical
-    lt: 1
-  alert:
-    for: 5m
-  documentation:
-    title: MySQL Server Availability
-    description: A boolean value that indicates whether the MySQL process is running or not.
-    recommendedResponse: Run mysql-diag and check the MySQL Server logs for errors.
-- name: mysql_galera_wsrep_ready
-  promql:  _$origin_galera_wsrep_ready{source_id="$source_id", deployment="$deployment"}
-  thresholds:
-  - level: critical
-    eq: 0
-  - level: warning
-    lt: 1
-  alert:
-    for: 5m
-  documentation:
-    title: Galera Cluster Node Readiness
-    description: "Shows whether each cluster node can accept queries. Returns only 0 or 1. When this metric is 0, almost all queries to that node fail with the error:
-ERROR 1047 (08501) Unknown Command"
-    recommendedResponse: "Run mysql-diag and check the MySQL Server logs for errors. \nMake sure there has been no infrastructure event that affects intra-cluster communication. \nEnsure that wsrep_ready has not been set to off by using the query: SHOW STATUS LIKE 'wsrep_ready';"
-- name: mysql_galera_cluster_size
-  promql:  _$origin_galera_wsrep_cluster_size{source_id="$source_id", deployment="$deployment"}
-  thresholds:
-  <%
-    instance_count = link("mysql").instances.length
-    if instance_count >= 3
-      crit_threshold = 2
-    else
-      crit_threshold = 1
-    end
-  %>
+spec:
+  product:
+    name: mysql-pxc
+    version: v2.5
+
+  indicators:
+  - name: mysql_availability
+    promql:  _$origin_available{source_id="$source_id", deployment="$deployment"}
+    thresholds:
     - level: critical
-      lt: <%= crit_threshold %>
-  <% if instance_count >= 3 %>
+      operator: lt
+      value: 1
+    alert:
+      for: 5m
+    documentation:
+      title: MySQL Server Availability
+      description: A boolean value that indicates whether the MySQL process is running or not.
+      recommendedResponse: Run mysql-diag and check the MySQL Server logs for errors.
+  - name: mysql_galera_wsrep_ready
+    promql:  _$origin_galera_wsrep_ready{source_id="$source_id", deployment="$deployment"}
+    thresholds:
+    - level: critical
+      operator: eq
+      value: 0
     - level: warning
-      lt: 3
+      operator: lt
+      value: 1
+    alert:
+      for: 5m
+    documentation:
+      title: Galera Cluster Node Readiness
+      description: "Shows whether each cluster node can accept queries. Returns only 0 or 1. When this metric is 0, almost all queries to that node fail with the error:
+  ERROR 1047 (08501) Unknown Command"
+      recommendedResponse: "Run mysql-diag and check the MySQL Server logs for errors. \nMake sure there has been no infrastructure event that affects intra-cluster communication. \nEnsure that wsrep_ready has not been set to off by using the query: SHOW STATUS LIKE 'wsrep_ready';"
+  - name: mysql_galera_cluster_size
+    promql:  _$origin_galera_wsrep_cluster_size{source_id="$source_id", deployment="$deployment"}
+    thresholds:
+    <%
+      instance_count = link("mysql").instances.length
+      if instance_count >= 3
+        crit_threshold = 2
+      else
+        crit_threshold = 1
+      end
+    %>
+      - level: critical
+        operator: lt
+        value: <%= crit_threshold %>
+    <% if instance_count >= 3 %>
+      - level: warning
+        operator: lt
+        value: 3
+    <% end %>
+    alert:
+      for: 5m
+    documentation:
+      title: Galera Cluster Size
+      description: "The number of cluster nodes with which each node is communicating normally. Use: When running in a multi-node configuration, this metric indicates if each member of the cluster is communicating normally with all other nodes."
+      recommendedResponse: "Run mysql-diag and check the MySQL Server logs for errors."
+
+  <% if link("mysql").instances.length >= 3 %>
+  - name: mysql_galera_cluster_status
+    promql:  sum(_$origin_galera_wsrep_cluster_status{source_id="$source_id", deployment="$deployment"})
+    thresholds:
+      - level: critical
+        operator: lt
+        value: 2
+      - level: warning
+        operator: lt
+        value: 3
+    alert:
+      for: 5m
+    documentation:
+      title: Galera Cluster Status
+      description: "Shows the primary status of the cluster component that the node is in."
+      recommendedResponse: "Check node status to ensure that they are all in working order and able to receive write-sets. Run mysql-diag and check the MySQL Server logs for errors."
   <% end %>
-  alert:
-    for: 5m
-  documentation:
-    title: Galera Cluster Size
-    description: "The number of cluster nodes with which each node is communicating normally. Use: When running in a multi-node configuration, this metric indicates if each member of the cluster is communicating normally with all other nodes."
-    recommendedResponse: "Run mysql-diag and check the MySQL Server logs for errors."
-
-<% if link("mysql").instances.length >= 3 %>
-- name: mysql_galera_cluster_status
-  promql:  sum(_$origin_galera_wsrep_cluster_status{source_id="$source_id", deployment="$deployment"})
-  thresholds:
-    - level: critical
-      lt: 2
-    - level: warning
-      lt: 3
-  alert:
-    for: 5m
-  documentation:
-    title: Galera Cluster Status
-    description: "Shows the primary status of the cluster component that the node is in."
-    recommendedResponse: "Check node status to ensure that they are all in working order and able to receive write-sets. Run mysql-diag and check the MySQL Server logs for errors."
-<% end %>
-- name: mysql_net_connections
-  promql:  _$origin_net_connections{source_id="$source_id", deployment="$deployment"}
-  thresholds:
-    - level: critical
-      gt: .9
-    - level: warning
-      gt: .8
-  alert:
-    for: 1m
-  documentation:
-    title: Connections per Second
-    description: "Connections per second made to the server."
-    recommendedResponse: "Run mysql-diag and check the MySQL Server logs for errors. When approaching 100% of max connections, Apps may be experiencing times when they cannot connect to the database. The connections per second for the cluster vary based on application instances and app utilization. If this threshold is met or exceeded for an extended period of time, monitor app usage to ensure everything is behaving as expected."
-- name: mysql_performance_cpu_utilization_percent
-  promql:  _$origin_performance_cpu_utilization_percent{source_id="$source_id", deployment="$deployment"}
-  thresholds:
-    - level: critical
-      gt: .9
-    - level: warning
-      gt: .8
-  alert:
-    for: 10m
-  documentation:
-    title: CPU Utilization Percent
-    description: "CPU time being consumed by the MySQL service."
-    recommendedResponse: "Run mysql-diag and check the MySQL Server logs for errors. When approaching 100% of max connections, Apps may be experiencing times when they cannot connect to the database. The connections per second for the cluster vary based on application instances and app utilization. Determine what is using so much CPU. If it is from normal processes, update the service instance to use a plan with larger CPU capacity."
-- name: mysql_performance_queries_delta
-  promql:  _$origin_performance_queries_delta{source_id="$source_id", deployment="$deployment"}
-  thresholds:
-    - level: critical
-      eq: 0
-  alert:
-    for: 2m
-  documentation:
-    title: Queries Delta
-    description: "The number of statements executed by the server over the last 30 seconds."
-    recommendedResponse: "Run mysql-diag and check the MySQL Server logs for errors. Investigate the MySQL server logs, such as the audit log, to understand why query rate changed and determine appropriate action."
+  - name: mysql_net_connections
+    promql:  _$origin_net_connections{source_id="$source_id", deployment="$deployment"}
+    thresholds:
+      - level: critical
+        operator: gt
+        value: .9
+      - level: warning
+        operator: gt
+        value: .8
+    alert:
+      for: 1m
+    documentation:
+      title: Connections per Second
+      description: "Connections per second made to the server."
+      recommendedResponse: "Run mysql-diag and check the MySQL Server logs for errors. When approaching 100% of max connections, Apps may be experiencing times when they cannot connect to the database. The connections per second for the cluster vary based on application instances and app utilization. If this threshold is met or exceeded for an extended period of time, monitor app usage to ensure everything is behaving as expected."
+  - name: mysql_performance_cpu_utilization_percent
+    promql:  _$origin_performance_cpu_utilization_percent{source_id="$source_id", deployment="$deployment"}
+    thresholds:
+      - level: critical
+        operator: gt
+        value: .9
+      - level: warning
+        operator: gt
+        value: .8
+    alert:
+      for: 10m
+    documentation:
+      title: CPU Utilization Percent
+      description: "CPU time being consumed by the MySQL service."
+      recommendedResponse: "Run mysql-diag and check the MySQL Server logs for errors. When approaching 100% of max connections, Apps may be experiencing times when they cannot connect to the database. The connections per second for the cluster vary based on application instances and app utilization. Determine what is using so much CPU. If it is from normal processes, update the service instance to use a plan with larger CPU capacity."
+  - name: mysql_performance_queries_delta
+    promql:  _$origin_performance_queries_delta{source_id="$source_id", deployment="$deployment"}
+    thresholds:
+      - level: critical
+        operator: eq
+        value: 0
+    alert:
+      for: 2m
+    documentation:
+      title: Queries Delta
+      description: "The number of statements executed by the server over the last 30 seconds."
+      recommendedResponse: "Run mysql-diag and check the MySQL Server logs for errors. Investigate the MySQL server logs, such as the audit log, to understand why query rate changed and determine appropriate action."


### PR DESCRIPTION
Updates the Indicator Document to apiVersion indicatorprotocol.io/v1. This makes the document Kubernetes-compatible, and ensures the document will be usable in the 1.0.0 release of Indicator Protocol, as v0 is deprecated.