### PR TITLE
Update indicators.yml.erb

### DIFF
--- a/jobs/mysql-metrics/templates/indicators.yml.erb
+++ b/jobs/mysql-metrics/templates/indicators.yml.erb
@@ -7,6 +7,7 @@ metadata:
     deployment: <%= spec.deployment %>
     source_id: <%= p("mysql-metrics.source_id") %>
     origin: <%= p("mysql-metrics.origin").gsub(/[^A-Z,a-z,0-9]/,"_") %>
+    component: mysql-metrics
 
 spec:
   product:


### PR DESCRIPTION
Adds a `component` key to metadata to ensure that documents for different jobs don't overwrite each other.